### PR TITLE
layer.conf: remove meta-measured from LAYERDEPENDS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -26,7 +26,6 @@ LAYERDEPENDS_starlingX-layer = "\
 	openstack-controller-deploy-layer \
 	openstack-qemu-layer \
 	openstack-swift-deploy-layer \
-	measured \
 	signing-key \
 	efi-secure-boot \
 	encrypted-storage \


### PR DESCRIPTION
There is no 'thud' branch in meta-measured and we don't
use it for now, so remove it from the LAYERDEPENDS.

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>